### PR TITLE
fix: restore refreshFilter getter to a function

### DIFF
--- a/src/store/store.js
+++ b/src/store/store.js
@@ -78,7 +78,7 @@ const todoListStatsState = selector({
 /* undo sort + filter */
 const refreshFilterState = selector({
   key: 'refreshFilterState',
-  get: null,
+  get: () => null,
   set: ({ reset }) => {
     reset(todoListSortState);
     reset(todoListFilterState);


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce to Scratch Project? Put an `x` in the boxes that apply. -->
- [x] Bugfix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Refactor (change which changes the codebase without affecting its external behavior)
- [ ] Non-breaking change (fix or feature that would causes existing functionality to work as expected)
- [ ] Breaking change (fix or feature that would cause existing functionality to __not__ work as expected)
## Purpose
<!--- Describe the problem or feature. Link to the issue(s) fixed by this pull request if applicable. -->
I broke the set-only selector in my last PR. Just realized it when I was was having issues running the test suites.
## Approach
<!--- How does your change address the problem? -->
Sets the get value for refreshFilterState to an empty arrow function returning null.
## Resources
<!--- Describe the research stage. Link to any blog posts, video, patterns, libraries, addons, or other resources that helped you to solve this problem. -->
[Recoil issue #325](https://github.com/facebookexperimental/Recoil/issues/325) seems to assert that write-only selectors are an anti-pattern, so we may want to refactor this part of the app at some point.
