### PR TITLE
fix: regroup atoms + selectors to generate correct test setup

### DIFF
--- a/mock-package/index.js
+++ b/mock-package/index.js
@@ -45,11 +45,7 @@ export const selector = (config) => {
   const newSelector = recoilSelector(newConfig);
 
   // Add selector object to appropriate exportable array
-  if (set) {
-    writeables.push(newSelector);
-  } else {
-    readables.push(newSelector);
-  }
+  readables.push(newSelector);
 
   // Return the normal selector out to the app
   return newSelector;


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce to Scratch Project? Put an `x` in the boxes that apply. -->
- [x] Bugfix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Refactor (change which changes the codebase without affecting its external behavior)
- [ ] Non-breaking change (fix or feature that would causes existing functionality to work as expected)
- [ ] Breaking change (fix or feature that would cause existing functionality to __not__ work as expected)
## Purpose
<!--- Describe the problem or feature. Link to the issue(s) fixed by this pull request if applicable. -->
Writeable selector was causing incorrect test setups in output.
## Approach
<!--- How does your change address the problem? -->
Moves _all_ selectors, including set-able, to the `readable` array, and only includes atoms in the `writeable` array.
## Notes
<!--- Describe the research stage. Link to any blog posts, video, patterns, libraries, addons, or other resources that helped you to solve this problem. -->
May still be some deeply bugs hidden for very specific series of interactions, but this PR fixes all bugs that were readily reproducible.