### PR TITLE
Add async selectors to fetch inspirational quotes for header box

### DIFF
--- a/src/components/Quotes.jsx
+++ b/src/components/Quotes.jsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { useRecoilValue, useSetRecoilState } from 'recoil';
+import { quoteTextState, quoteNumberState, xkcdState } from '../store/store';
+
+const Quotes = () => {
+  const setQuoteNumber = useSetRecoilState(quoteNumberState);
+  const quoteText = useRecoilValue(quoteTextState);
+  const xkcdURL = useRecoilValue(xkcdState);
+
+  return (
+    <>
+      <div id="quoteContainer">
+        <p>{quoteText}</p>
+        <button type="button" onClick={() => setQuoteNumber(Math.floor(Math.random() * 1643))}>
+          New Quote
+        </button>
+      </div>
+      <img alt="xkcd" src={xkcdURL} />
+    </>
+  );
+};
+
+export default Quotes;

--- a/src/components/TodoList.jsx
+++ b/src/components/TodoList.jsx
@@ -3,15 +3,20 @@ import { useRecoilValue } from 'recoil';
 import { sortedTodoListState } from '../store/store';
 import TodoItem from './TodoItem';
 import TodoItemCreator from './TodoItemCreator';
-import '../styles/styles.css';
 import TodoListFilters from './TodoListFilters';
+import Quotes from './Quotes';
+import '../styles/styles.css';
 
 const TodoList = () => {
   const todoList = useRecoilValue(sortedTodoListState);
 
   return (
     <div className="mainContainer">
-      <div className="row" />
+      <div className="row quoteBox">
+        <React.Suspense fallback={<small>Loading...</small>}>
+          <Quotes />
+        </React.Suspense>
+      </div>
 
       <div className="row todosDisplayRow">
         <h1>Totally Todos!</h1>

--- a/src/styles/styles.css
+++ b/src/styles/styles.css
@@ -4,6 +4,7 @@ html {
   background-color: rgb(48, 48, 48);
   color: whitesmoke;
   font-family: 'Palanquin', sans-serif;
+  overflow: hidden;
 }
 
 h1 {
@@ -153,3 +154,39 @@ button span {
   opacity: .60;
 }
 
+/* ----------QuoteBox---------- */
+#quoteContainer {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+}
+
+#quoteContainer p{
+  white-space: pre-wrap;
+}
+
+.quoteBox {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  background-color: rgb(63, 63, 63);
+  box-shadow: 0px 0px 35px 20px rgba(10, 10, 10, 0.096);
+  border-radius: 5px;
+  margin: auto;
+  padding: 12px;
+}
+
+.quoteBox img {
+  margin: 20px;
+  height: 150px;
+  width: 150px;
+}
+
+.quoteBox button {
+  width: 150px;
+}
+
+.quoteBox button:hover {
+  border: 1px solid whitesmoke;
+  cursor: pointer;
+}


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce to Scratch Project? Put an `x` in the boxes that apply. -->
- [ ] Bugfix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Refactor (change which changes the codebase without affecting its external behavior)
- [x] Non-breaking change (fix or feature that would causes existing functionality to work as expected)
- [ ] Breaking change (fix or feature that would cause existing functionality to __not__ work as expected)
## Purpose
<!--- Describe the problem or feature. Link to the issue(s) fixed by this pull request if applicable. -->
Added both promise-based and async/await style selectors for package testing.
## Approach
<!--- How does your change address the problem? -->
Added an atom to hold a random number, which can be regenerated by clicking a button.

When the loads or changes, one selector fetches an array of inspirational quotes from an external api & returns a Promise that resolves to a formatted string with the quote at that index. Another selector runs as an async function and awaits a fetch request to xkcd for a comic URL. Currently, this fetch request always throws an error, which causes a fallback hardcoded img url to be returned instead.
## Resources
<!--- Describe the research stage. Link to any blog posts, video, patterns, libraries, addons, or other resources that helped you to solve this problem. -->
Quotes API: https://type.fit/api/quotes
## Screenshot(s)
<!--- (if applicable--you can delete otherwise) -->
<!--- Include a screenshot here if the change you made changes the look of the site in any way! -->
![async-quotes](https://user-images.githubusercontent.com/42079810/90346130-42d04a00-dfdb-11ea-8974-7fcf8a77a365.png)