### PR TITLE
feat: add 'all' checkbox with writeable selector + fix xkcd CORS

### DIFF
--- a/src/components/TodoList.jsx
+++ b/src/components/TodoList.jsx
@@ -4,6 +4,7 @@ import { sortedTodoListState } from '../store/store';
 import TodoItem from './TodoItem';
 import TodoItemCreator from './TodoItemCreator';
 import TodoListFilters from './TodoListFilters';
+import TodoQuickCheck from './TodoQuickCheck';
 import Quotes from './Quotes';
 import '../styles/styles.css';
 
@@ -22,6 +23,7 @@ const TodoList = () => {
         <h1>Totally Todos!</h1>
 
         <div className="todosContainer">
+          <TodoQuickCheck />
           <TodoItemCreator />
           {todoList.map((todoItem) => (
             <TodoItem key={todoItem.id} item={todoItem} />

--- a/src/components/TodoQuickCheck.jsx
+++ b/src/components/TodoQuickCheck.jsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { useRecoilState, useRecoilValue } from 'recoil';
+import Checkbox from '@material-ui/core/Checkbox';
+import { allCompleteState, filteredListContentState } from '../store/store';
+
+const TodoQuickCheck = () => {
+  const [allComplete, setAllComplete] = useRecoilState(allCompleteState);
+  const display = useRecoilValue(filteredListContentState);
+
+  return (
+    display && (
+      <div id="quickCheck">
+        <Checkbox
+          disableRipple
+          checked={allComplete}
+          color="default"
+          inputProps={{ 'aria-label': 'primary checkbox' }}
+          onChange={() => setAllComplete(!allComplete)}
+        />
+        all
+      </div>
+    )
+  );
+};
+
+export default TodoQuickCheck;

--- a/src/styles/styles.css
+++ b/src/styles/styles.css
@@ -190,3 +190,13 @@ button span {
   border: 1px solid whitesmoke;
   cursor: pointer;
 }
+
+/* ---------- TodoQuickCheck ---------- */
+
+#quickCheck {
+  font-family: Arial, Helvetica, sans-serif;
+}
+
+#quickCheck svg {
+  color: #af6358;
+}

--- a/test/selectors.test.js
+++ b/test/selectors.test.js
@@ -11,6 +11,8 @@ import {
   refreshFilterState,
 } from '../src/store/store';
 
+console.error = jest.fn();
+
 // using react testing library alone might make more sense
 // test('filteredTodoListState should correctly derive state', () => {
 //   // first arg needs to be custom hook


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce to Scratch Project? Put an `x` in the boxes that apply. -->
- [x] Bugfix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Refactor (change which changes the codebase without affecting its external behavior)
- [x] Non-breaking change (fix or feature that would causes existing functionality to work as expected)
- [ ] Breaking change (fix or feature that would cause existing functionality to __not__ work as expected)
## Purpose
<!--- Describe the problem or feature. Link to the issue(s) fixed by this pull request if applicable. -->
Include additional writeable selectors in app.
## Approach
<!--- How does your change address the problem? -->
Add a checkbox in the upper left over the main container to check / uncheck all visible items. This uses a readable selector depending on another readable selector, and a read/write selector depending on another readable selector & writing to an atom. **All test output appears to still be working correctly.**

Also proxies the xkcd fetch through cors-anywhere.
## Screenshot(s)
<!--- (if applicable--you can delete otherwise) -->
<!--- Include a screenshot here if the change you made changes the look of the site in any way! -->
![Screen Shot 2020-08-18 at 08 42 19 AM](https://user-images.githubusercontent.com/42079810/90534660-dbc3aa00-e12e-11ea-93ba-8328dd86e524.png)
